### PR TITLE
96boardsctl: raspberry pi fix

### DIFF
--- a/96boardsctl/96boardsctl.c
+++ b/96boardsctl/96boardsctl.c
@@ -96,7 +96,7 @@ int main(int argc, char *argv[])
 	char *cmd[3], *serialnum = NULL;
 	int count = 0;
 	int rc;
-	char c;
+	signed char c;
 
 	progname = argv[0];
 


### PR DESCRIPTION
Getopt_long exits with a -1 when it's done parsing the cmd line.
Seems the char on a raspberry pi is unsigned.